### PR TITLE
test: ensure that circom-qap params verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 [[package]]
 name = "ark-groth16"
 version = "0.3.0"
-source = "git+https://github.com/gakonst/groth16?branch=feat/customizable-r1cs-to-qap#dcd1dc75e56da4666b28473aed4ca349f2f226a1"
+source = "git+https://github.com/kobigurk/groth16?branch=feat/customizable-r1cs-to-qap#a3c4783f879fefeebbaf60caf5e50e9488243c63"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",

--- a/crates/ark-circom/Cargo.toml
+++ b/crates/ark-circom/Cargo.toml
@@ -19,7 +19,7 @@ ark-ff = "0.3.0"
 ark-std = "0.3.0"
 ark-bn254 = "0.3.0"
 ark-r1cs-std = "0.3.1"
-ark-groth16 = { git = "https://github.com/gakonst/groth16", version = "0.3.0", branch = "feat/customizable-r1cs-to-qap" }
+ark-groth16 = { git = "https://github.com/kobigurk/groth16", version = "0.3.0", branch = "feat/customizable-r1cs-to-qap" }
 ark-poly = { version = "^0.3.0", default-features = false }
 ark-relations = "0.3.0"
 

--- a/crates/ark-circom/src/circom_qap.rs
+++ b/crates/ark-circom/src/circom_qap.rs
@@ -97,7 +97,7 @@ impl QAPCalculator for R1CStoQAPCircom {
     fn h_query_scalars<F: PrimeField, D: EvaluationDomain<F>>(
         max_power: usize,
         t: F,
-        zt: F,
+        _: F,
         delta_inverse: F,
     ) -> Result<Vec<F>, SynthesisError> {
         // the usual H query has domain-1 powers. Z has domain powers. So HZ has 2*domain-1 powers.

--- a/crates/ark-circom/src/circom_qap.rs
+++ b/crates/ark-circom/src/circom_qap.rs
@@ -104,7 +104,7 @@ impl QAPCalculator for R1CStoQAPCircom {
     ) -> Result<Vec<F>, SynthesisError> {
         // the usual H query has domain-1 powers. Z has domain powers. So HZ has 2*domain-1 powers.
         let mut scalars = cfg_into_iter!(0..2 * max_power + 1)
-            .map(|i| delta_inverse * &t.pow([i as u64]))
+            .map(|i| delta_inverse * t.pow([i as u64]))
             .collect::<Vec<_>>();
         let domain_size = scalars.len();
         let domain = D::new(domain_size).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;

--- a/crates/ark-circom/src/circom_qap.rs
+++ b/crates/ark-circom/src/circom_qap.rs
@@ -62,17 +62,19 @@ impl QAPCalculator for R1CStoQAPCircom {
         domain.ifft_in_place(&mut a);
         domain.ifft_in_place(&mut b);
 
-        let domain_size_double = 2 * domain_size;
-        let domain_double =
-            D::new(domain_size_double).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
+        let root_of_unity = {
+            let domain_size_double = 2 * domain_size;
+            let domain_double =
+                D::new(domain_size_double).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
+            domain_double.element(1)
+        };
+        D::distribute_powers_and_mul_by_const(&mut a, root_of_unity, F::one());
+        D::distribute_powers_and_mul_by_const(&mut b, root_of_unity, F::one());
 
-        a.resize(domain_size_double, F::zero());
-        b.resize(domain_size_double, F::zero());
+        domain.fft_in_place(&mut a);
+        domain.fft_in_place(&mut b);
 
-        domain_double.fft_in_place(&mut a);
-        domain_double.fft_in_place(&mut b);
-
-        let mut ab = domain_double.mul_polynomials_in_evaluation_domain(&a, &b);
+        let mut ab = domain.mul_polynomials_in_evaluation_domain(&a, &b);
         drop(a);
         drop(b);
 
@@ -84,14 +86,14 @@ impl QAPCalculator for R1CStoQAPCircom {
             });
 
         domain.ifft_in_place(&mut c);
-        c.resize(domain_size_double, F::zero());
-        domain_double.fft_in_place(&mut c);
+        D::distribute_powers_and_mul_by_const(&mut c, root_of_unity, F::one());
+        domain.fft_in_place(&mut c);
 
         cfg_iter_mut!(ab)
             .zip(c)
             .for_each(|(ab_i, c_i)| *ab_i -= &c_i);
 
-        Ok(ab.into_iter().skip(1).step_by(2).collect())
+        Ok(ab)
     }
 
     fn h_query_scalars<F: PrimeField, D: EvaluationDomain<F>>(

--- a/crates/ark-circom/src/circom_qap.rs
+++ b/crates/ark-circom/src/circom_qap.rs
@@ -2,7 +2,7 @@ use ark_ff::PrimeField;
 use ark_groth16::r1cs_to_qap::{evaluate_constraint, QAPCalculator, R1CStoQAP};
 use ark_poly::EvaluationDomain;
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
-use ark_std::{cfg_iter, cfg_iter_mut, vec};
+use ark_std::{cfg_into_iter, cfg_iter, cfg_iter_mut, vec};
 use core::ops::Deref;
 
 /// Implements the witness map used by snarkjs. The arkworks witness map calculates the
@@ -92,5 +92,22 @@ impl QAPCalculator for R1CStoQAPCircom {
             .for_each(|(ab_i, c_i)| *ab_i -= &c_i);
 
         Ok(ab.into_iter().skip(1).step_by(2).collect())
+    }
+
+    fn h_query_scalars<F: PrimeField, D: EvaluationDomain<F>>(
+        max_power: usize,
+        t: F,
+        zt: F,
+        delta_inverse: F,
+    ) -> Result<Vec<F>, SynthesisError> {
+        // the usual H query has domain-1 powers. Z has domain powers. So HZ has 2*domain-1 powers.
+        let mut scalars = cfg_into_iter!(0..2 * max_power + 1)
+            .map(|i| delta_inverse * &t.pow([i as u64]))
+            .collect::<Vec<_>>();
+        let domain_size = scalars.len();
+        let domain = D::new(domain_size).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
+        // generate the lagrange coefficients
+        domain.ifft_in_place(&mut scalars);
+        Ok(cfg_into_iter!(scalars).skip(1).step_by(2).collect())
     }
 }

--- a/crates/ark-circom/tests/groth16.rs
+++ b/crates/ark-circom/tests/groth16.rs
@@ -1,10 +1,11 @@
-use ark_circom::{CircomBuilder, CircuitConfig};
+use ark_circom::{circom_qap::R1CStoQAPCircom, CircomBuilder, CircuitConfig};
 use ark_std::rand::thread_rng;
 use color_eyre::Result;
 
 use ark_bn254::Bn254;
 use ark_groth16::{
-    create_random_proof as prove, generate_random_parameters, prepare_verifying_key, verify_proof,
+    create_random_proof as prove, create_random_proof_with_qap, generate_random_parameters,
+    generate_random_parameters_with_qap, prepare_verifying_key, verify_proof,
 };
 
 #[test]
@@ -21,18 +22,28 @@ fn groth16_proof() -> Result<()> {
     let circom = builder.setup();
 
     let mut rng = thread_rng();
-    let params = generate_random_parameters::<Bn254, _, _>(circom, &mut rng)?;
+
+    let params = generate_random_parameters::<Bn254, _, _>(circom.clone(), &mut rng)?;
+    let params_circom =
+        generate_random_parameters_with_qap::<Bn254, _, _, R1CStoQAPCircom>(circom, &mut rng)?;
 
     let circom = builder.build()?;
 
     let inputs = circom.get_public_inputs().unwrap();
 
-    let proof = prove(circom, &params, &mut rng)?;
+    let proof = prove(circom.clone(), &params, &mut rng)?;
+    let proof_circom = create_random_proof_with_qap::<_, _, _, R1CStoQAPCircom>(
+        circom.clone(),
+        &params_circom,
+        &mut rng,
+    )?;
 
     let pvk = prepare_verifying_key(&params.vk);
-
     let verified = verify_proof(&pvk, &proof, &inputs)?;
+    assert!(verified);
 
+    let pvk_circom = prepare_verifying_key(&params_circom.vk);
+    let verified = verify_proof(&pvk_circom, &proof_circom, &inputs)?;
     assert!(verified);
 
     Ok(())


### PR DESCRIPTION
This fails - probably means we also need to adjust the `instance_map_with_evaluations` code to generate params a la snarkjs.